### PR TITLE
Fix for: Cannot initialize SchemaType from invalid String value http:…

### DIFF
--- a/Sources/CoreXLSX/Relationships.swift
+++ b/Sources/CoreXLSX/Relationships.swift
@@ -130,6 +130,10 @@ public struct Relationship: Codable, Equatable {
       """
       http://purl.oclc.org/ooxml/officeDocument/relationships/extendedProperties
       """
+    case sheetMetadata =
+      """
+      http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata
+      """
   }
 
   /// The identifier for this entity.


### PR DESCRIPTION
…//schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata